### PR TITLE
Trace lruvec introduction to cgroups

### DIFF
--- a/lruvec_cgroup_analysis.md
+++ b/lruvec_cgroup_analysis.md
@@ -1,0 +1,138 @@
+# Linux内核中lruvec引入cgroup的分析报告
+
+## 一、lruvec结构体概述
+
+`struct lruvec` 是Linux内核中用于管理LRU（Least Recently Used，最近最少使用）链表的核心数据结构。该结构体定义在 `include/linux/mmzone.h` 中：
+
+```c
+struct lruvec {
+    struct list_head        lists[NR_LRU_LISTS];
+    /* per lruvec lru_lock for memcg */
+    spinlock_t              lru_lock;
+    /*
+     * These track the cost of reclaiming one LRU - file or anon -
+     * over the other. As the observed cost of reclaiming one LRU
+     * increases, the reclaim scan balance tips toward the other.
+     */
+    unsigned long           anon_cost;
+    unsigned long           file_cost;
+    // ... 其他成员
+};
+```
+
+## 二、lruvec与cgroup的集成架构
+
+### 2.1 mem_cgroup_per_node结构体
+
+在当前Linux内核中，`lruvec` 被嵌入到 `mem_cgroup_per_node` 结构体中（定义在 `include/linux/memcontrol.h`）：
+
+```c
+struct mem_cgroup_per_node {
+    // ... 其他成员
+    struct lruvec       lruvec;
+    CACHELINE_PADDING(_pad2_);
+    unsigned long       lru_zone_size[MAX_NR_ZONES][NR_LRU_LISTS];
+    struct mem_cgroup_reclaim_iter  iter;
+    // ... 其他成员
+};
+```
+
+### 2.2 mem_cgroup结构体
+
+`mem_cgroup` 结构体通过 `nodeinfo` 数组管理每个NUMA节点的信息：
+
+```c
+struct mem_cgroup {
+    struct cgroup_subsys_state css;
+    // ... 其他成员
+    struct mem_cgroup_per_node *nodeinfo[0]; // memcg在每个node下的信息
+};
+```
+
+### 2.3 架构设计意义
+
+这种设计使得：
+- 每个memory cgroup在每个NUMA节点上都有独立的LRU链表
+- 内存回收可以针对特定cgroup和特定节点进行精细化管理
+- 实现了per-memcg的内存回收策略
+
+## 三、代码中的使用示例
+
+在内核代码中，通过以下函数获取特定memcg的lruvec：
+
+```c
+// mm/workingset.c
+lruvec = mem_cgroup_lruvec(memcg, pgdat);
+
+// mm/memcontrol.c
+pn = container_of(lruvec, struct mem_cgroup_per_node, lruvec);
+```
+
+## 四、历史演进：per-memcg LRU的引入
+
+### 4.1 引入背景
+
+在早期Linux内核版本中，LRU链表是全局的或者per-zone的。随着容器技术和cgroup的发展，需要对不同cgroup的内存使用进行独立管理，因此引入了per-memcg LRU的概念。
+
+### 4.2 关键补丁集（Patchset）
+
+根据分析，per-memcg LRU功能主要在**Linux 3.3版本**期间引入，时间大约在**2011年末至2012年初**。主要涉及以下几个重要的补丁系列：
+
+#### 1. Johannes Weiner的per-memcg LRU补丁系列
+- **时间**：2011年末至2012年初
+- **主要内容**：实现了"make per-memcg LRU lists exclusive"
+- **版本**：合入Linux 3.3-rc1
+- **意义**：使每个memcg拥有独占的LRU链表，而不是与全局LRU共享
+
+#### 2. Konstantin Khlebnikov的lruvec整合补丁
+- **补丁标题**："mm: collect LRU list heads into struct lruvec"
+- **时间**：2012年
+- **主要内容**：将分散的LRU链表头整合到struct lruvec结构体中
+- **意义**：统一了LRU链表的管理接口
+
+#### 3. 其他贡献者
+- **KAMEZAWA Hiroyuki**：早期memcg功能的主要贡献者
+- **Hugh Dickins**：内存管理子系统的重要贡献者
+
+### 4.3 技术演进路径
+
+1. **第一阶段**：基础memcg功能实现（2.6.x时代）
+2. **第二阶段**：引入per-memcg统计和计数
+3. **第三阶段**：实现per-memcg LRU链表（Linux 3.3）
+4. **第四阶段**：持续优化和改进
+
+## 五、关键设计决策
+
+### 5.1 为什么需要per-memcg LRU？
+
+1. **隔离性**：不同cgroup的内存回收互不影响
+2. **公平性**：每个cgroup根据自己的内存使用情况进行回收
+3. **可控性**：可以针对特定cgroup设置不同的回收策略
+4. **性能**：减少全局锁竞争，提高并发性能
+
+### 5.2 实现挑战
+
+1. **内存开销**：每个cgroup/node组合都需要维护独立的lruvec
+2. **复杂性**：代码逻辑更加复杂
+3. **兼容性**：需要同时支持启用和未启用memcg的场景
+
+## 六、查找补丁的方法
+
+如需查找具体的补丁信息，可以使用以下方法：
+
+```bash
+# 在Linux内核Git仓库中搜索
+git log --grep="per-memcg LRU" --since="2011-01-01" --until="2012-12-31"
+git log --grep="lruvec" --grep="memcg" --all-match
+git log --author="Johannes Weiner" --grep="LRU"
+
+# 查看特定文件的历史
+git log -p include/linux/memcontrol.h
+git log -p mm/memcontrol.c
+```
+
+## 七、总结
+
+`lruvec` 在cgroup中的引入是Linux内核内存管理子系统的一个重要里程碑，主要发生在**Linux 3.3版本（2012年初）**期间。这个改进通过**Johannes Weiner等人的per-memcg LRU补丁系列**实现，使得每个memory cgroup能够在每个NUMA节点上维护独立的LRU链表，从而实现了更加精细和高效的内存管理。
+
+这个架构设计一直延续至今，成为了容器技术和云原生应用内存隔离的基础设施之一。


### PR DESCRIPTION
Add an analysis report detailing the introduction of `lruvec` into cgroup in Linux kernel 3.3.

This report identifies the key patchsets and contributors, explaining the architectural changes and the design significance of per-memcg LRU for memory isolation and performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-339f8405-f33a-4280-a498-c0a0c3ced751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-339f8405-f33a-4280-a498-c0a0c3ced751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

