### PR TITLE
Trace vfs_read call stacks for socket and file

### DIFF
--- a/vfs_read_call_stack.md
+++ b/vfs_read_call_stack.md
@@ -1,0 +1,115 @@
+# VFS read系统调用的两种调用栈追踪
+
+## 1. Socket读取路径总结
+
+```
+vfs_read (fs/read_write.c)
+├── rw_verify_area
+├── filp->f_op->read_iter (socket_file_ops->read_iter = sock_read_iter)
+│   └── new_sync_read (fs/read_write.c)
+│       ├── init_sync_kiocb (include/linux/fs.h)
+│       ├── iov_iter_ubuf (include/linux/uio.h)
+│       └── filp->f_op->read_iter
+│           └── sock_read_iter (net/socket.c)
+│               └── sock_recvmsg
+│                   ├── security_socket_recvmsg
+│                   └── sock_recvmsg_nosec
+│                       └── sock->ops->recvmsg (对于TCP: inet_recvmsg)
+│                           └── inet_recvmsg (net/ipv4/af_inet.c)
+│                               └── sk->sk_prot->recvmsg
+│                                   └── tcp_recvmsg (net/ipv4/tcp.c)
+│                                       ├── sk_busy_loop
+│                                       ├── lock_sock
+│                                       ├── tcp_recvmsg_locked
+│                                       │   ├── tcp_try_recv
+│                                       │   ├── skb_copy_datagram_msg
+│                                       │   └── tcp_recv_timestamp
+│                                       └── release_sock
+└── 更新文件位置 (*ppos = kiocb.ki_pos)
+```
+
+## 2. 本地文件(ext4)读取路径总结
+
+```
+vfs_read (fs/read_write.c)
+├── rw_verify_area
+├── filp->f_op->read_iter (ext4_file_operations->read_iter = ext4_file_read_iter)
+│   └── new_sync_read (fs/read_write.c)
+│       ├── init_sync_kiocb (include/linux/fs.h)
+│       ├── iov_iter_ubuf (include/linux/uio.h)
+│       └── filp->f_op->read_iter
+│           └── ext4_file_read_iter (fs/ext4/file.c)
+│               └── generic_file_read_iter (mm/filemap.c)
+│                   ├── [DIRECT I/O路径]
+│                   │   ├── kiocb_write_and_wait
+│                   │   ├── file_accessed
+│                   │   └── mapping->a_ops->direct_IO
+│                   │       └── ext4_direct_IO (fs/ext4/inode.c)
+│                   │           ├── ext4_dio_read_iter
+│                   │           └── iomap_dio_rw
+│                   └── [BUFFERED I/O路径]
+│                       └── filemap_read (mm/filemap.c)
+│                           ├── folio_batch_init
+│                           ├── filemap_get_pages
+│                           │   ├── find_get_pages_contig
+│                           │   └── page_cache_sync_readahead
+│                           ├── copy_folio_to_iter
+│                           │   └── copy_page_to_iter
+│                           │       └── copy_to_user
+│                           └── file_accessed
+└── 更新文件位置 (*ppos = kiocb.ki_pos)
+```
+
+## 3. 验证结果
+
+您的说法是**完全正确的**：
+
+### Socket读取
+- `struct file_operations` 确实是 `socket_file_ops` (定义在 net/socket.c:156)
+- 其中的 `read_iter` 确实是 `sock_read_iter` (net/socket.c:158)
+
+### 本地文件读取
+- 对于ext4文件系统，`struct file_operations` 是 `ext4_file_operations` (fs/ext4/file.c:963)
+- 其 `read_iter` 是 `ext4_file_read_iter`，最终调用 `generic_file_read_iter` (fs/ext4/file.c:147)
+
+## 4. 关键差异
+
+### Socket路径特点：
+- 通过socket层的抽象接口
+- 涉及网络协议栈（TCP/UDP等）
+- 数据来源于网络缓冲区（sk_buff）
+- 需要处理网络协议相关的逻辑（如TCP的流控、拥塞控制等）
+
+### 文件系统路径特点：
+- 通过页缓存（page cache）机制
+- 支持Direct I/O和Buffered I/O两种模式
+- 数据来源于磁盘块设备
+- 涉及文件系统的元数据管理和块设备I/O调度
+
+## 5. VFS层的统一抽象
+
+VFS通过 `file_operations` 结构体实现了对不同类型文件的统一抽象：
+
+```c
+// fs/read_write.c:552-581
+ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
+{
+    // 权限和参数检查
+    ret = rw_verify_area(READ, file, pos, count);
+    
+    // 根据file_operations选择调用路径
+    if (file->f_op->read)
+        ret = file->f_op->read(file, buf, count, pos);
+    else if (file->f_op->read_iter)
+        ret = new_sync_read(file, buf, count, pos);  // 大多数现代驱动使用这个
+    
+    // 文件系统通知和统计
+    if (ret > 0) {
+        fsnotify_access(file);
+        add_rchar(current, ret);
+    }
+    return ret;
+}
+```
+
+这种设计使得上层应用程序可以使用相同的系统调用（read/write）来操作不同类型的文件对象，无论是本地文件、socket、设备文件还是其他特殊文件。


### PR DESCRIPTION
Add detailed call stack analysis for `vfs_read` when reading from sockets and local files.

---
<a href="https://cursor.com/background-agent?bcId=bc-faf4db04-a009-48a3-bf64-d03f363bc366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-faf4db04-a009-48a3-bf64-d03f363bc366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

